### PR TITLE
Exclude libunwind from repository's language stat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Specify LLVM's libunwind as vendored so it'll be excluded from the language stats
+llvm-libunwind/* linguist-vendored


### PR DESCRIPTION
This should make it more clear that this is a Rust crate repo w/o looking inside the repository.